### PR TITLE
Fix Lift configurations

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,1 @@
+tools = ["Bill Of Materials", "Open Source Vulnerabilities"]

--- a/backend/.lift.toml
+++ b/backend/.lift.toml
@@ -1,1 +1,1 @@
-# Future Lift configurations
+disableTools = ["Bill Of Materials", "Open Source Vulnerabilities"]

--- a/frontend/.lift.toml
+++ b/frontend/.lift.toml
@@ -1,1 +1,1 @@
-disableTools=["ESLint"]
+disableTools = ["ESLint", "Bill Of Materials", "Open Source Vulnerabilities"]


### PR DESCRIPTION
- Move the "Bill Of Materials" and "Open Source Vulnerabilities" to the top level
  - This prevents them from generating multiple results for the dependencies