### PR TITLE
Allow <object> tags to include files from the same origin

### DIFF
--- a/infra/images/podman-prod/nginx.nix
+++ b/infra/images/podman-prod/nginx.nix
@@ -38,7 +38,7 @@
     add_header 'Referrer-Policy' 'origin-when-cross-origin';
 
     # Disable embedding as a frame
-    add_header X-Frame-Options DENY;
+    add_header X-Frame-Options SAMEORIGIN;
 
     # Prevent injection of code in other mime types (XSS Attacks)
     add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
DENY is causing the bug where the `<object>` logo tag is not loading and instead falling back to the `<img>` tag.

Resolves #86 