### PR TITLE
Add bind mount to fix Let's Encrypt registration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "lastModified": 1662220400,
+        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "lastModified": 1664088401,
+        "narHash": "sha256-JCl3kbaD1mdPNAGu0nvTMpC+dcb9AT2kmvRH/yKZI9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "rev": "4c4cf9979e19fabf7ceccbf7c8eda553d836cdf6",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "lastModified": 1664088401,
+        "narHash": "sha256-JCl3kbaD1mdPNAGu0nvTMpC+dcb9AT2kmvRH/yKZI9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "rev": "4c4cf9979e19fabf7ceccbf7c8eda553d836cdf6",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,9 @@
           tfswitch
           packer
 
+          # Nix
+          nixpkgs-fmt
+
         ];
 
         RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";

--- a/infra/images/podman-base/configuration.nix
+++ b/infra/images/podman-base/configuration.nix
@@ -6,7 +6,8 @@
 
 {
   imports =
-    [ # Include the results of the hardware scan.
+    [
+      # Include the results of the hardware scan.
       ./hardware-configuration.nix
     ];
 
@@ -25,12 +26,12 @@
   networking.interfaces.enp1s0.useDHCP = true; # Laptop Qemu/KVM NIC
   networking.interfaces.ens3.useDHCP = true; # Digital Ocean NIC 1
   networking.interfaces.ens4.useDHCP = true; # Digital OCean NIC 2
-  
+
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.mutableUsers = false; # So we can blow away any set passwords
-  
+
   users.users.root.hashedPassword = "$6$/Rkez4AJT4Dlsz2x$qQpfdUtAwuWJYH5tIlaxAhJp06JVlUA4rK4gDmfy7nwBHiHkJK1PtnGJa8xgv3o4fhtY0CxcuInIJ.41efWrM.";
-  
+
   users.users.allie = {
     isNormalUser = true;
     extraGroups = [ "wheel" "docker" "podman" ];
@@ -76,16 +77,16 @@
 
   virtualisation = {
     podman = {
-     enable = true;
-  
-     dockerCompat = true;
+      enable = true;
+
+      dockerCompat = true;
     };
   };
 
   # List services that you want to enable:
 
   # Enable the OpenSSH daemon.
-  services.openssh ={ 
+  services.openssh = {
     enable = true;
     permitRootLogin = "yes";
   };

--- a/infra/images/podman-base/hardware-configuration.nix
+++ b/infra/images/podman-base/hardware-configuration.nix
@@ -8,7 +8,8 @@
 
 {
   imports =
-    [ (modulesPath + "/profiles/qemu-guest.nix")
+    [
+      (modulesPath + "/profiles/qemu-guest.nix")
     ];
 
   boot.initrd.availableKernelModules = [ "ahci" "ata_piix" "uhci_hcd" "virtio_scsi" "xhci_pci" "virtio_pci" "sr_mod" "virtio_blk" ];
@@ -17,13 +18,13 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/7436c553-8e3c-42c8-8f51-0e9ce25be6a4";
+    {
+      device = "/dev/disk/by-uuid/7436c553-8e3c-42c8-8f51-0e9ce25be6a4";
       fsType = "ext4";
     };
 
   swapDevices =
-    [ { device = "/dev/disk/by-uuid/d083f112-c80d-412b-b30d-7c6551a7dc5a"; }
-    ];
+    [{ device = "/dev/disk/by-uuid/d083f112-c80d-412b-b30d-7c6551a7dc5a"; }];
 
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;

--- a/infra/images/podman-prod/configuration.nix
+++ b/infra/images/podman-prod/configuration.nix
@@ -6,7 +6,8 @@
 
 {
   imports =
-    [ # Include the results of the hardware scan.
+    [
+      # Include the results of the hardware scan.
       ./hardware-configuration.nix
 
       # This is commented out as it cannot be run during the Packer
@@ -32,7 +33,7 @@
   networking.useDHCP = false;
   networking.interfaces.ens3.useDHCP = true; # Digital Ocean NIC 1
   networking.interfaces.ens4.useDHCP = true; # Digital OCean NIC 2
-  
+
   # Define a user accounts
   users.mutableUsers = false; # So we can blow away any set passwords
 
@@ -78,36 +79,44 @@
   # Temporary until I can lock this down better
   security.sudo.wheelNeedsPassword = false;
   security.sudo.extraRules = [
-    { users = [ "automation" ]; 
-      commands = [ { 
-        command = "/run/current-system/sw/bin/podman"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/wrappers/bin/mount"; 
-        options = [ "NOPASSWD" ]; } 
-        { 
-        command = "/run/current-system/sw/bin/tee"; 
-        options = [ "NOPASSWD" ]; } 
-        { 
-        command = "/run/current-system/sw/bin/nixos-rebuild"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-channel"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-env"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/rm -f /nix/var/nix/gcroots/auto/*"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-collect-garbage"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/sed"; 
-        options = [ "NOPASSWD" ]; }
-
-      ]; 
+    {
+      users = [ "automation" ];
+      commands = [{
+        command = "/run/current-system/sw/bin/podman";
+        options = [ "NOPASSWD" ];
+      }
+        {
+          command = "/run/wrappers/bin/mount";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/tee";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nixos-rebuild";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-channel";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-env";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/rm -f /nix/var/nix/gcroots/auto/*";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-collect-garbage";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/sed";
+          options = [ "NOPASSWD" ];
+        }];
     }
   ];
 
@@ -126,9 +135,9 @@
 
   virtualisation = {
     podman = {
-     enable = true;
-  
-     dockerCompat = true;
+      enable = true;
+
+      dockerCompat = true;
     };
   };
 

--- a/infra/images/podman-prod/hardware-configuration.nix
+++ b/infra/images/podman-prod/hardware-configuration.nix
@@ -5,7 +5,8 @@
 
 {
   imports =
-    [ (modulesPath + "/profiles/qemu-guest.nix")
+    [
+      (modulesPath + "/profiles/qemu-guest.nix")
     ];
 
   boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "virtio_pci" "virtio_scsi" "virtio_blk" ];
@@ -14,13 +15,13 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/7436c553-8e3c-42c8-8f51-0e9ce25be6a4";
+    {
+      device = "/dev/disk/by-uuid/7436c553-8e3c-42c8-8f51-0e9ce25be6a4";
       fsType = "ext4";
     };
 
   swapDevices =
-    [ { device = "/dev/disk/by-uuid/d083f112-c80d-412b-b30d-7c6551a7dc5a"; }
-    ];
+    [{ device = "/dev/disk/by-uuid/d083f112-c80d-412b-b30d-7c6551a7dc5a"; }];
 
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/infra/images/podman-prod/nginx.nix
+++ b/infra/images/podman-prod/nginx.nix
@@ -22,63 +22,66 @@
     sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
 
     commonHttpConfig = ''
-    # Note: This is breaking the site right now. TODO get HSTS working
-    #
-    # Add HSTS header with preloading to HTTPS requests.
-    # Adding this header to HTTP requests is discouraged
-    # map $scheme $hsts_header {
-    #    https   "max-age=31536000; includeSubdomains; preload";
-    # }
-    # add_header Strict-Transport-Security $hsts_header;
+      # Note: This is breaking the site right now. TODO get HSTS working
+      #
+      # Add HSTS header with preloading to HTTPS requests.
+      # Adding this header to HTTP requests is discouraged
+      # map $scheme $hsts_header {
+      #    https   "max-age=31536000; includeSubdomains; preload";
+      # }
+      # add_header Strict-Transport-Security $hsts_header;
 
-    # Enable CSP for your services.
-    #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
+      # Enable CSP for your services.
+      #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
 
-    # Minimize information leaked to other domains
-    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+      # Minimize information leaked to other domains
+      add_header 'Referrer-Policy' 'origin-when-cross-origin';
 
-    # Disable embedding as a frame
-    add_header X-Frame-Options SAMEORIGIN;
+      # Disable embedding as a frame
+      add_header X-Frame-Options SAMEORIGIN;
 
-    # Prevent injection of code in other mime types (XSS Attacks)
-    add_header X-Content-Type-Options nosniff;
+      # Prevent injection of code in other mime types (XSS Attacks)
+      add_header X-Content-Type-Options nosniff;
 
-    # Enable XSS protection of the browser.
-    # May be unnecessary when CSP is configured properly (see above)
-    add_header X-XSS-Protection "1; mode=block";
+      # Enable XSS protection of the browser.
+      # May be unnecessary when CSP is configured properly (see above)
+      add_header X-XSS-Protection "1; mode=block";
 
-    # This might create errors
-    proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
+      # This might create errors
+      proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
     '';
 
-    
 
-    virtualHosts = let gameNightConfig = {
-    useACMEHost = "gamenight.gay";
-    forceSSL = false;
-    addSSL = true;
-    sslCertificate = "/mnt/game-night-prod/certificates/acme/gamenight.gay/cert.pem";
-    locations."/.well-known/acme-challenge/" = {
-        root = "/mnt/game-night-prod/certificates/acme/acme-challenge";
-        extraConfig =
-            "if ($scheme = 'https') { rewrite ^ http://$http_host$request_uri? permanent; }";
-    };
-    locations."/" = {
-        proxyPass = "http://127.0.0.1:2727";
-        proxyWebsockets = true; # needed if you need to use WebSocket
-        extraConfig =
-        # required when the target is also TLS server with multiple hosts
-        "proxy_ssl_server_name on;" +
-        # required when the server wants to use HTTP Authentication
-        "proxy_pass_header Authorization;";
+
+    virtualHosts =
+      let
+        gameNightConfig = {
+          useACMEHost = "gamenight.gay";
+          forceSSL = false;
+          addSSL = true;
+          sslCertificate = "/mnt/game-night-prod/certificates/acme/gamenight.gay/cert.pem";
+          locations."/.well-known/acme-challenge/" = {
+            root = "/mnt/game-night-prod/certificates/acme/acme-challenge";
+            extraConfig =
+              "if ($scheme = 'https') { rewrite ^ http://$http_host$request_uri? permanent; }";
+          };
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:2727";
+            proxyWebsockets = true; # needed if you need to use WebSocket
+            extraConfig =
+              # required when the target is also TLS server with multiple hosts
+              "proxy_ssl_server_name on;" +
+              # required when the server wants to use HTTP Authentication
+              "proxy_pass_header Authorization;";
+          };
         };
-    }; 
-    in {
-    "gamenight.gay" = gameNightConfig;
-    "www.gamenight.gay" = gameNightConfig;
-    "prod.gamenight.gay" = gameNightConfig;
-    };
-};
+      in
+      {
+        "gamenight.gay" = gameNightConfig;
+        "www.gamenight.gay" = gameNightConfig;
+        "prod.gamenight.gay" = gameNightConfig;
+      };
+  };
 
   # TODO - Commented out until we can get this to not get us rate limited by LE
   # Cert is copied and available on the volume

--- a/infra/images/podman-prod/nginx.nix
+++ b/infra/images/podman-prod/nginx.nix
@@ -7,6 +7,19 @@
 
   users.users.acme = {
     extraGroups = [ "acme" ];
+    isSystemUser = true;
+  };
+
+  users.groups = {
+    acme = { gid = 995; };
+  };
+
+  users.users.acme.group = "acme";
+
+  # Workaround so the Let's Encrypt cert gets stored on the network
+  fileSystems."/var/lib/acme" = {
+    device = "/mnt/game-night-prod/certificates/acme";
+    options = [ "bind" ];
   };
 
   services.nginx = {
@@ -59,9 +72,8 @@
           useACMEHost = "gamenight.gay";
           forceSSL = false;
           addSSL = true;
-          sslCertificate = "/mnt/game-night-prod/certificates/acme/gamenight.gay/cert.pem";
           locations."/.well-known/acme-challenge/" = {
-            root = "/mnt/game-night-prod/certificates/acme/acme-challenge";
+            root = "/var/lib/acme/.challenges";
             extraConfig =
               "if ($scheme = 'https') { rewrite ^ http://$http_host$request_uri? permanent; }";
           };
@@ -83,17 +95,15 @@
       };
   };
 
-  # TODO - Commented out until we can get this to not get us rate limited by LE
-  # Cert is copied and available on the volume
-  # security.acme.acceptTerms = true;
-  # security.acme.renewInterval = "weekly";
-  # security.acme.preliminarySelfsigned = true;
-  # security.acme.certs = {
-  #   "gamenight.gay" = {
-  #     directory = "/mnt/game-night-prod/certificates/acme/<name>";
-  #     webroot = "/mnt/game-night-prod/certificates/acme/acme-challenge";
-  #     extraDomainNames = [ "www.gamenight.gay" "prod.gamenight.gay" ];
-  #     email = "admin@gamenight.gay";
-  #   };
-  # };
+
+  security.acme.acceptTerms = true;
+  security.acme.renewInterval = "weekly";
+  security.acme.preliminarySelfsigned = true;
+  security.acme.certs = {
+    "gamenight.gay" = {
+      webroot = "/var/lib/acme/.challenges";
+      extraDomainNames = [ "www.gamenight.gay" "prod.gamenight.gay" ];
+      email = "admin@gamenight.gay";
+    };
+  };
 }

--- a/infra/terraform/nix/configuration.nix
+++ b/infra/terraform/nix/configuration.nix
@@ -6,7 +6,8 @@
 
 {
   imports =
-    [ # Include the results of the hardware scan.
+    [
+      # Include the results of the hardware scan.
       ./hardware-configuration.nix
 
       ./nginx.nix
@@ -26,7 +27,7 @@
   networking.useDHCP = false;
   networking.interfaces.ens3.useDHCP = true; # Digital Ocean NIC 1
   networking.interfaces.ens4.useDHCP = true; # Digital OCean NIC 2
-  
+
   # Define a user accounts
   users.mutableUsers = false; # So we can blow away any set passwords
 
@@ -72,36 +73,44 @@
   # Temporary until I can lock this down better
   security.sudo.wheelNeedsPassword = false;
   security.sudo.extraRules = [
-    { users = [ "automation" ]; 
-      commands = [ { 
-        command = "/run/current-system/sw/bin/podman"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/wrappers/bin/mount"; 
-        options = [ "NOPASSWD" ]; } 
-        { 
-        command = "/run/current-system/sw/bin/tee"; 
-        options = [ "NOPASSWD" ]; } 
-        { 
-        command = "/run/current-system/sw/bin/nixos-rebuild"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-channel"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-env"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/rm -f /nix/var/nix/gcroots/auto/*"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/nix-collect-garbage"; 
-        options = [ "NOPASSWD" ]; }
-        { 
-        command = "/run/current-system/sw/bin/sed"; 
-        options = [ "NOPASSWD" ]; }
-
-      ]; 
+    {
+      users = [ "automation" ];
+      commands = [{
+        command = "/run/current-system/sw/bin/podman";
+        options = [ "NOPASSWD" ];
+      }
+        {
+          command = "/run/wrappers/bin/mount";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/tee";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nixos-rebuild";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-channel";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-env";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/rm -f /nix/var/nix/gcroots/auto/*";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/nix-collect-garbage";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/sed";
+          options = [ "NOPASSWD" ];
+        }];
     }
   ];
 
@@ -120,9 +129,9 @@
 
   virtualisation = {
     podman = {
-     enable = true;
-  
-     dockerCompat = true;
+      enable = true;
+
+      dockerCompat = true;
     };
   };
 

--- a/infra/terraform/nix/nginx.nix
+++ b/infra/terraform/nix/nginx.nix
@@ -13,8 +13,14 @@
   users.groups = {
     acme = { gid = 995; };
   };
-  
+
   users.users.acme.group = "acme";
+
+  # Workaround so the Let's Encrypt cert gets stored on the network
+  fileSystems."/var/lib/acme" = {
+    device = "/mnt/game-night-prod/certificates/acme";
+    options = [ "bind" ];
+  };
 
   services.nginx = {
     enable = true;
@@ -29,76 +35,75 @@
     sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
 
     commonHttpConfig = ''
-    # Note: This is breaking the site right now. TODO get HSTS working
-    #
-    # Add HSTS header with preloading to HTTPS requests.
-    # Adding this header to HTTP requests is discouraged
-    # map $scheme $hsts_header {
-    #    https   "max-age=31536000; includeSubdomains; preload";
-    # }
-    # add_header Strict-Transport-Security $hsts_header;
+      # Note: This is breaking the site right now. TODO get HSTS working
+      #
+      # Add HSTS header with preloading to HTTPS requests.
+      # Adding this header to HTTP requests is discouraged
+      # map $scheme $hsts_header {
+      #    https   "max-age=31536000; includeSubdomains; preload";
+      # }
+      # add_header Strict-Transport-Security $hsts_header;
 
-    # Enable CSP for your services.
-    #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
+      # Enable CSP for your services.
+      #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
 
-    # Minimize information leaked to other domains
-    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+      # Minimize information leaked to other domains
+      add_header 'Referrer-Policy' 'origin-when-cross-origin';
 
-    # Disable embedding as a frame
-    add_header X-Frame-Options SAMEORIGIN;
+      # Disable embedding as a frame
+      add_header X-Frame-Options SAMEORIGIN;
 
-    # Prevent injection of code in other mime types (XSS Attacks)
-    add_header X-Content-Type-Options nosniff;
+      # Prevent injection of code in other mime types (XSS Attacks)
+      add_header X-Content-Type-Options nosniff;
 
-    # Enable XSS protection of the browser.
-    # May be unnecessary when CSP is configured properly (see above)
-    add_header X-XSS-Protection "1; mode=block";
+      # Enable XSS protection of the browser.
+      # May be unnecessary when CSP is configured properly (see above)
+      add_header X-XSS-Protection "1; mode=block";
 
-    # This might create errors
-    proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
+      # This might create errors
+      proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
     '';
 
-    
 
-    virtualHosts = let gameNightConfig = {
-    #useACMEHost = "gamenight.gay";
-    forceSSL = false;
-    addSSL = true;
-    sslCertificate = "/mnt/game-night-prod/certificates/acme/gamenight.gay/cert.pem";
-    sslCertificateKey = "/mnt/game-night-prod/certificates/acme/gamenight.gay/key.pem";
-    locations."/.well-known/acme-challenge/" = {
-        root = "/mnt/game-night-prod/certificates/acme/acme-challenge";
-        extraConfig =
-            "if ($scheme = 'https') { rewrite ^ http://$http_host$request_uri? permanent; }";
-    };
-    locations."/" = {
-        proxyPass = "http://127.0.0.1:2727";
-        proxyWebsockets = true; # needed if you need to use WebSocket
-        extraConfig =
-        # required when the target is also TLS server with multiple hosts
-        "proxy_ssl_server_name on;" +
-        # required when the server wants to use HTTP Authentication
-        "proxy_pass_header Authorization;";
+
+    virtualHosts =
+      let
+        gameNightConfig = {
+          useACMEHost = "gamenight.gay";
+          forceSSL = false;
+          addSSL = true;
+          locations."/.well-known/acme-challenge/" = {
+            root = "/var/lib/acme/.challenges";
+            extraConfig =
+              "if ($scheme = 'https') { rewrite ^ http://$http_host$request_uri? permanent; }";
+          };
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:2727";
+            proxyWebsockets = true; # needed if you need to use WebSocket
+            extraConfig =
+              # required when the target is also TLS server with multiple hosts
+              "proxy_ssl_server_name on;" +
+              # required when the server wants to use HTTP Authentication
+              "proxy_pass_header Authorization;";
+          };
         };
-    }; 
-    in {
-    "gamenight.gay" = gameNightConfig;
-    "www.gamenight.gay" = gameNightConfig;
-    "prod.gamenight.gay" = gameNightConfig;
-    };
-};
+      in
+      {
+        "gamenight.gay" = gameNightConfig;
+        "www.gamenight.gay" = gameNightConfig;
+        "prod.gamenight.gay" = gameNightConfig;
+      };
+  };
 
-  # TODO - Commented out until we can get this to not get us rate limited by LE
-  # Cert is copied and available on the volume
-  # security.acme.acceptTerms = true;
-  # security.acme.renewInterval = "weekly";
-  # security.acme.preliminarySelfsigned = true;
-  # security.acme.certs = {
-  #   "gamenight.gay" = {
-  #     directory = "/mnt/game-night-prod/certificates/acme/<name>";
-  #     webroot = "/mnt/game-night-prod/certificates/acme/acme-challenge";
-  #     extraDomainNames = [ "www.gamenight.gay" "prod.gamenight.gay" ];
-  #     email = "admin@gamenight.gay";
-  #   };
-  # };
+
+  security.acme.acceptTerms = true;
+  security.acme.renewInterval = "weekly";
+  security.acme.preliminarySelfsigned = true;
+  security.acme.certs = {
+    "gamenight.gay" = {
+      webroot = "/var/lib/acme/.challenges";
+      extraDomainNames = [ "www.gamenight.gay" "prod.gamenight.gay" ];
+      email = "admin@gamenight.gay";
+    };
+  };
 }


### PR DESCRIPTION
- Resolves #107 
- Add workaround to bind mount `/var/lib/acme` to a directory on the network drive. This prevents the certificate registration from happening unless the cert is going to expire. Cannot change the acme configuration as that variable is read-only and configured in the package config
- Added `nixpkgs-fmt` to the devShell and formatted all `.nix` files
- Ran `nix flake update` to update `flake.lock`